### PR TITLE
Make script compatible with newest linux version and reusable for video un-/muting

### DIFF
--- a/zoom_key_send.sh
+++ b/zoom_key_send.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+DEFAULT_SHORTCUT='alt+a'
+SHORTCUT=${1:-$DEFAULT_SHORTCUT}
+
 send_to_zoom() {
     # due to "-e" we'll stop if zoom window is not found.
     zoom=$(xdotool search --name "Zoom Meeting")
@@ -18,4 +21,4 @@ send_to_zoom() {
     xdotool windowfocus "$cur_focus"
 }
 
-send_to_zoom "alt+a"
+send_to_zoom $SHORTCUT

--- a/zoom_key_send.sh
+++ b/zoom_key_send.sh
@@ -4,7 +4,7 @@ set -e
 
 send_to_zoom() {
     # due to "-e" we'll stop if zoom window is not found.
-    zoom=$(xdotool search --name "Zoom Meeting ID:")
+    zoom=$(xdotool search --name "Zoom Meeting")
     cur_active=$(xdotool getactivewindow)
     cur_focus=$(xdotool getwindowfocus)
 


### PR DESCRIPTION
1) make script compatible with newest linux version: 
the current version 5.2. has no "ID" in the meeting window title and was not found by xdotool
2) make script reusable for video un-/muting
custom parameters can now be passed to the send_zoom_key script which allows to register multiple global shortcuts (audio/video/etc)