### PR TITLE
Restore mouse position after (un)mute

### DIFF
--- a/zoom_key_send.sh
+++ b/zoom_key_send.sh
@@ -10,6 +10,11 @@ send_to_zoom() {
     zoom=$(xdotool search --name "Zoom Meeting")
     cur_active=$(xdotool getactivewindow)
     cur_focus=$(xdotool getwindowfocus)
+    
+    mouselocation=$(xdotool getmouselocation)
+    mouseX=$(echo "$mouselocation" | cut -d' ' -f1 | cut -d':' -f2)
+    mouseY=$(echo "$mouselocation" | cut -d' ' -f2 | cut -d':' -f2)
+    mouseScreen=$(echo "$mouselocation" | cut -d' ' -f3 | cut -d':' -f2)
 
     xdotool windowfocus "$zoom"
     xdotool windowactivate "$zoom"
@@ -19,6 +24,7 @@ send_to_zoom() {
 
     xdotool windowactivate "$cur_active"
     xdotool windowfocus "$cur_focus"
+    xdotool mousemove --screen "$mouseScreen" "$mouseX" "$mouseY"
 }
 
 send_to_zoom $SHORTCUT


### PR DESCRIPTION
Restores the original mouse position after sending keystrokes to the zoom window.

Strongly dependent on the output of `xdotool getmouselocation` command.